### PR TITLE
Fix breaking dockerfile things

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine AS BUILD
 WORKDIR /build
 COPY . /build
-RUN rm -r Procfile LICENSE .dockerignore .github/ readme.md
+RUN rm -r Procfile LICENSE README.md
 RUN npm install --production
 
 FROM node:16-alpine


### PR DESCRIPTION
Due to .github folder not being including in local cloning, the docker build process would break. not a good thing.